### PR TITLE
node_modules を docker-compose の bind から除外する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
+      - nest_node_module:/app/api/node_modules
       - type: bind
         source: .
         target: /app
@@ -28,6 +29,7 @@ services:
     ports:
       - '3001:3001'
     volumes:
+      - next_node_module:/app/front/node_modules
       - type: bind
         source: .
         target: /app
@@ -36,3 +38,5 @@ services:
 
 volumes:
   merch_psgrs:
+  nest_node_module:
+  next_node_module:


### PR DESCRIPTION
# 何をした？
node_modules を docker-compose のbind から除外し、ホストでの変更が反映されないようにした。
[参考記事](https://qiita.com/kino-ma/items/eae3dac942e899f9a77b)

# 不安なところある？(特にレビューしてほしいところ)
node_modules なので特に不都合でない認識だけど、何か懸念点あれば。。

# 動作確認の方法
特に無し！

# 解決するissue
close #22 